### PR TITLE
Fix crash in startupmenu

### DIFF
--- a/src/main/java/dev/tauri/jsg/client/screen/gui/mainmenu/GuiCustomMainMenu.java
+++ b/src/main/java/dev/tauri/jsg/client/screen/gui/mainmenu/GuiCustomMainMenu.java
@@ -328,7 +328,6 @@ public class GuiCustomMainMenu extends Screen {
         RenderSystem.disableBlend();
         poseStack.popPose();
         poseStack.popPose();
-        poseStack.popPose();
     }
 
     @Override


### PR DESCRIPTION
The crash is a `PoseStack` underflow that only becomes relevant when there are other mods that touch the PostStack later.